### PR TITLE
fix: don't track if shouldTrack is set to false after hook

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -104,7 +104,9 @@ export default defineNitroPlugin(async (nitro) => {
 
       await nitro.hooks.callHook('applicationinsights:trackRequest:before', event, trackInfo)
 
-      event.$appInsights.client.trackRequest(trackInfo)
+      if (event.$appInsights.shouldTrack) {
+        event.$appInsights.client.trackRequest(trackInfo)
+      }
     }
   })
 


### PR DESCRIPTION
This PR prevent tracking request if the user set `shouldTrack` to false after `'applicationinsights:trackRequest:before'`