### PR TITLE
fix: fix create$fetchInterceptors name

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -49,22 +49,24 @@ export function create$fetchInterceptors (event?: H3Event): NitroFetchOptions<an
         })
     },
     onResponse (context) {
+      const requestPath = context.request.toString()
       event?.$appInsights.client.trackDependency({
         dependencyTypeName: 'HTTP',
         duration: startTime ? (Date.now() - startTime) : 0,
-        name: `${context.options.method?.toUpperCase() || 'GET'} ${context.response.url}`,
-        data: context.response.url,
+        name: `${context.options.method || 'GET'} ${requestPath}`,
+        data: requestPath,
         resultCode: context.response.status,
         success: true,
         contextObjects
       })
     },
     onResponseError (context) {
+      const requestPath = context.request.toString()
       event?.$appInsights.client.trackDependency({
         dependencyTypeName: 'HTTP',
         duration: startTime ? (Date.now() - startTime) : 0,
-        name: `${context.options.method?.toUpperCase() || 'GET'} ${context.response.url}`,
-        data: context.response.url,
+        name: `${context.options.method?.toUpperCase() || 'GET'} ${requestPath}`,
+        data: requestPath,
         resultCode: context.response.status,
         success: false,
         contextObjects

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -52,7 +52,7 @@ export function create$fetchInterceptors (event?: H3Event): NitroFetchOptions<an
       event?.$appInsights.client.trackDependency({
         dependencyTypeName: 'HTTP',
         duration: startTime ? (Date.now() - startTime) : 0,
-        name: `${context.options.method} ${context.response.url}}`,
+        name: `${context.options.method?.toUpperCase() || 'GET'} ${context.response.url}`,
         data: context.response.url,
         resultCode: context.response.status,
         success: true,
@@ -63,7 +63,7 @@ export function create$fetchInterceptors (event?: H3Event): NitroFetchOptions<an
       event?.$appInsights.client.trackDependency({
         dependencyTypeName: 'HTTP',
         duration: startTime ? (Date.now() - startTime) : 0,
-        name: `${context.options.method} ${context.response.url}}`,
+        name: `${context.options.method?.toUpperCase() || 'GET'} ${context.response.url}`,
         data: context.response.url,
         resultCode: context.response.status,
         success: false,


### PR DESCRIPTION
fix #48 

The method may be undefined so we'll fallback to `GET` and use `context.request` to set the name