### PR TITLE
chore: v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nitro-applicationinsights",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Application insights plugin for nitro.",
   "repository": "huang-julien/nitro-applicationinsights",
   "license": "MIT",


### PR DESCRIPTION
# nitro-applicationinsights v0.6.0

Few breaking changes is happening on this version.

You may also expect next minor version to change nitro-applicationinsights into a module.

## Migration steps

- Add nitro-applicationinsights to `externals.inline`:
```ts
export default defineNitroConfig({
    externals: {
        inline: ['nitro-applicationinsights']
    }
})
```
- env to runtime config:
  - You simply need to change the name of your variables. See [nitro doc](https://nitro.unjs.io/guide/configuration#production) for the name of you env variables.
- utilities imports:
  -  You need to import from `nitro-applicationinsights/runtime` instead of `nitro-applicationinsights`
-  getTraceparentHeader to getTraceparentHeaders:
   - It's the same signature, only the name has changed

## Features
- ⚠️ feat!: move env to runtimeConfig #51 
 
## Fixes
- fix: fix create$fetchInterceptors name #50 
- fix(deps): move h3 and nitropack to peerdeps to avoid type augment conflict #47 
- fix: force resolution of mlly to 1.4.0 #55 

## Refactor/Chore
- ⚠️ refactor!: move utilities to /runtime export #44 
- ⚠️ refactor!: rename getTraceparentHeader to getTraceparentHeaders #46 

## Docs

-  docs: improve doc for create$fetchInterceptor #45 
-  docs: explain how to inline the plugin #56 