### PR TITLE
fix: fix various build issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@ export default defineNitroConfig({
     modules: ['nitro-applicationinsights']
 })
 ```
-
-⚠️ This module force enable `experimental.legacyExternals` in your nitro config.
-
  
 Et voilà ! You now have application insights node for Nitro
 

--- a/build.config.ts
+++ b/build.config.ts
@@ -17,10 +17,11 @@ export default defineBuildConfig({
     {
       builder: 'rollup',
       input: './src/index.ts'
-    }
+    },
   ],
   declaration: true,
   rollup: {
-    emitCJS: true
-  }
+    emitCJS: true,
+  },
+  externals: ['#imports'],
 })

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
       "import": "./dist/runtime/index.mjs",
       "require": "./dist/runtime/index.js"
     },
-    "./runtime/plugin": {
-      "types": "./dist/runtime/plugin.d.ts",
-      "import": "./dist/runtime/plugin.mjs",
-      "require": "./dist/runtime/plugin.js"
+    "./runtime/*": {
+      "types": "./dist/runtime/*",
+      "import": "./dist/runtime/*",
+      "require": "./dist/runtime/*"
     }
   },
   "main": "./dist/index.cjs",
@@ -60,8 +60,8 @@
   "packageManager": "pnpm@8.15.6",
   "dependencies": {
     "applicationinsights": "^2.9.5",
-    "pathe": "^1.1.1",
-    "defu": "^6.1.4"
+    "mlly": "^1.6.1",
+    "pathe": "^1.1.1"
   },
   "peerDependencies": {
     "h3": ">=1.11.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "packageManager": "pnpm@8.15.6",
   "dependencies": {
     "applicationinsights": "^2.9.5",
+    "defu": "^6.1.4",
     "mlly": "^1.6.1",
     "pathe": "^1.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   applicationinsights:
     specifier: ^2.9.5
     version: 2.9.5
+  defu:
+    specifier: ^6.1.4
+    version: 6.1.4
   h3:
     specifier: '>=1.11.1'
     version: 1.11.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,12 @@ dependencies:
   applicationinsights:
     specifier: ^2.9.5
     version: 2.9.5
-  defu:
-    specifier: ^6.1.4
-    version: 6.1.4
   h3:
     specifier: '>=1.11.1'
     version: 1.11.1
+  mlly:
+    specifier: ^1.6.1
+    version: 1.6.1
   nitropack:
     specifier: '>=2.9.6'
     version: 2.9.6
@@ -4580,15 +4580,6 @@ packages:
       typescript: 5.4.4
     dev: true
 
-  /mlly@1.4.0:
-    resolution: {integrity: sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==}
-    dependencies:
-      acorn: 8.11.3
-      pathe: 1.1.2
-      pkg-types: 1.0.3
-      ufo: 1.4.0
-    dev: true
-
   /mlly@1.6.1:
     resolution: {integrity: sha512-vLgaHvaeunuOXHSmEbZ9izxPx3USsk8KCQ8iC+aTlp5sKRSoZvwhHh5L9VbKSaVC6sJDqbyohIS76E2VmHIPAA==}
     dependencies:
@@ -4832,7 +4823,7 @@ packages:
     dependencies:
       destr: 2.0.3
       node-fetch-native: 1.6.2
-      ufo: 1.4.0
+      ufo: 1.5.3
     dev: true
 
   /ofetch@1.3.4:
@@ -5832,6 +5823,7 @@ packages:
 
   /ufo@1.4.0:
     resolution: {integrity: sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ==}
+    dev: false
 
   /ufo@1.5.3:
     resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
@@ -5861,7 +5853,7 @@ packages:
       jiti: 1.21.0
       magic-string: 0.30.3
       mkdist: 1.3.0(typescript@5.4.4)
-      mlly: 1.4.0
+      mlly: 1.6.1
       pathe: 1.1.2
       pkg-types: 1.0.3
       pretty-bytes: 6.1.1

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,14 +3,6 @@ import { resolvePath } from "mlly"
 export default <NitroModule>{
   name: 'nitro-applicationinsights',
   async setup(nitro) {
-    // this fix the detection of applicationinsights as esm while waiting for mlly 2.0
-    if (!nitro.options.experimental?.legacyExternals) {
-      if (!nitro.options.experimental) {
-        nitro.options.experimental = {}
-      }
-      nitro.options.experimental.legacyExternals = true
-    }
-
     if (!nitro.options.externals) {
       nitro.options.externals = {}
     }


### PR DESCRIPTION
- force inline the plugin
- but NOT applicationinsights
- remove `legacyExternals`
- force trace applicationinsights main js file
- add `nitro-applicationinsights/runtime/plugin` in the array plugin instead of the absolute path