### PR TITLE
fix: use resolveId to mark #applicationinsights as sideeffect and external

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -9,12 +9,6 @@ export default <NitroModule>{
     if (!nitro.options.externals) {
       nitro.options.externals = {}
     }
-
-    nitro.options.alias['#applicationinsights'] = await resolvePath('nitro-applicationinsights/runtime/applicationinsights', {
-      extensions: ['.ts', '.mjs', '.js'],
-      url: [import.meta.url]
-    })
-
     nitro.options.externals.inline = nitro.options.externals.inline || []
     // force inline the plugin and the setup file
     nitro.options.externals.inline.push((id) => (
@@ -40,6 +34,12 @@ export default <NitroModule>{
           }
         }
       },
+      externals: {
+        traceInclude: [
+          // the main file doesn't seems to be traced
+          await resolvePath('applicationinsights/out/applicationinsights.js')
+        ]
+      },
       rollupConfig: {
         plugins: [
           // add necessary global var for applicationinsights
@@ -63,6 +63,18 @@ export default <NitroModule>{
                 };
               }
             }
+          },
+          {
+            name: 'applicationinsights-loader',
+            resolveId(id) {
+              if (id === '#applicationinsights') {
+                return {
+                  id: 'applicationinsights',
+                  moduleSideEffects: true,
+                  external: true
+                }
+              }
+            },
           }
         ]
       }


### PR DESCRIPTION
fix #121 

This PR change the way of aliasing `#applicationinsights`, instead of setting it in `alias` we use rollup `resolveId` and send additionnal information such as `external` and `moduleSideEffects`. We also can the issue again of the main file of applicationinsights not being traced