### PR TITLE
feat: use deprecated attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/context-async-hooks": "^1.30.0",
     "@opentelemetry/sdk-trace-node": "^1.30.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@types/node": "^22.9.0",
     "@vitest/coverage-v8": "^2.1.5",
     "@vitest/ui": "^2.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@opentelemetry/sdk-trace-node':
         specifier: ^1.30.0
         version: 1.30.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.28.0
+        version: 1.28.0
       '@types/node':
         specifier: ^22.9.0
         version: 22.9.0

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -2,14 +2,14 @@ import type { NitroAppPlugin } from 'nitropack'
 import defu from 'defu'
 import type { TNitroAppInsightsConfig } from '../types'
 import { useRuntimeConfig } from '#imports'
-import _Applicationinsights, { defaultClient } from 'applicationinsights'
+import _Applicationinsights from 'applicationinsights'
 import { metrics, trace, } from "@opentelemetry/api";
 // @ts-ignore wat ??
 import nitroOtelPlugin from "nitro-opentelemetry/runtime/plugin.mjs"
 import { registerInstrumentations } from "@opentelemetry/instrumentation";
 import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici"
 import { HttpInstrumentation } from "@opentelemetry/instrumentation-http"
-import {SemanticAttributes,  ATTR_HTTP_RESPONSE_STATUS_CODE ,SEMATTRS_HTTP_URL, SEMATTRS_HTTP_HOST, SEMATTRS_HTTP_METHOD, SEMATTRS_HTTP_ROUTE, SEMATTRS_HTTP_SCHEME, SEMATTRS_HTTP_STATUS_CODE, SEMATTRS_HTTP_TARGET, OTEL_STATUS_CODE_VALUE_OK, OTEL_STATUS_CODE_VALUE_ERROR } from "@opentelemetry/semantic-conventions"
+import { SEMATTRS_HTTP_URL, SEMATTRS_HTTP_HOST, SEMATTRS_HTTP_METHOD, SEMATTRS_HTTP_ROUTE, SEMATTRS_HTTP_SCHEME, SEMATTRS_HTTP_STATUS_CODE, OTEL_STATUS_CODE_VALUE_OK, OTEL_STATUS_CODE_VALUE_ERROR } from "@opentelemetry/semantic-conventions"
 
 const instrumentations = [
   new UndiciInstrumentation(),

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -11,9 +11,6 @@ import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici"
 import { HttpInstrumentation } from "@opentelemetry/instrumentation-http"
 import {SemanticAttributes,  ATTR_HTTP_RESPONSE_STATUS_CODE ,SEMATTRS_HTTP_URL, SEMATTRS_HTTP_HOST, SEMATTRS_HTTP_METHOD, SEMATTRS_HTTP_ROUTE, SEMATTRS_HTTP_SCHEME, SEMATTRS_HTTP_STATUS_CODE, SEMATTRS_HTTP_TARGET, OTEL_STATUS_CODE_VALUE_OK, OTEL_STATUS_CODE_VALUE_ERROR } from "@opentelemetry/semantic-conventions"
 
-process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL = "VERBOSE";
-process.env.APPLICATIONINSIGHTS_LOG_DESTINATION = "file";
-process.env.APPLICATIONINSIGHTS_LOGDIR = "D:/repo/nitro-applicationinsights/logs";
 const instrumentations = [
   new UndiciInstrumentation(),
   new HttpInstrumentation()


### PR DESCRIPTION
This PR adds deprecated attributes in spans. 

Seems like the platform itself isn't up to date with the latest change in OTEL semantic conventions from 3 months ago.