### PR TITLE
chore(release): 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nitro-applicationinsights",
-  "version": "0.15.0",
+  "version": "1.0.0",
   "description": "Application insights plugin for nitro.",
   "repository": "huang-julien/nitro-applicationinsights",
   "license": "MIT",


### PR DESCRIPTION
# V1 release

V1 will include applicationinsights 3 and Opentelemetry integration using [nitro-opentelemetry](https://github.com/huang-julien/nitro-opentelemetry)'s runtime plugin

### Moving to Applicationinsights 3 and Opentelemetry

See [Microsoft applicationinsights documentation](https://learn.microsoft.com/fr-fr/azure/azure-monitor/app/opentelemetry-nodejs-migrate?tabs=upgrade) for changes from applicationinsights 2 to 3.

See [nitro-opentelemetry](https://github.com/huang-julien/nitro-opentelemetry)

- `H3Event.$appInsights` has been removed in favor of Opentelemetry Span.
- `applicationinsights:trackError:before` has been removed.
- `applicationinsights:context:tags` has been removed. You can use `H3Event.context.span.setAttributes()` instead.
- `applicationinsights:trackRequest:before` has been removed. You can use `otel:span:end` nitro-opentelemetry hook instead.
- `applicationinsights:trackError:before` has been removed. You can directly hook into the error hook from nitro instead.
- You need to wrap all your event handlers with `defineTracedEventHandler`. See [event handlers](/event-handlers)