### PR TITLE
chore(release): 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,44 @@
 # Changelog
 
 
+## v0.15.0...v1.0.0
+
+[compare changes](https://github.com/huang-julien/nitro-applicationinsights/compare/v0.15.0...v1.0.0)
+
+### 🚀 Enhancements
+
+- Upgrade to applicationinsights v3 ([#130](https://github.com/huang-julien/nitro-applicationinsights/pull/130))
+- Use deprecated attributes ([#131](https://github.com/huang-julien/nitro-applicationinsights/pull/131))
+
+### 🔥 Performance
+
+- Remove traceInclude for main applicationinsights file ([045e7086](https://github.com/huang-julien/nitro-applicationinsights/commit/045e7086))
+
+### 🩹 Fixes
+
+- Add missing import ([4fcfa18e](https://github.com/huang-julien/nitro-applicationinsights/commit/4fcfa18e))
+- Run nitro otel plugin synchronously ([#134](https://github.com/huang-julien/nitro-applicationinsights/pull/134))
+- Set http status code in `otel:span:end` hook ([e68946f6](https://github.com/huang-julien/nitro-applicationinsights/commit/e68946f6))
+- Resolve route for SEMATTRS_HTTP_ROUTE ([e07d4089](https://github.com/huang-julien/nitro-applicationinsights/commit/e07d4089))
+
+### 📖 Documentation
+
+- Mention automated traces in how does it work ([55d4504b](https://github.com/huang-julien/nitro-applicationinsights/commit/55d4504b))
+- Add migration page ([309ddbe9](https://github.com/huang-julien/nitro-applicationinsights/commit/309ddbe9))
+- Add links to nitro-opentelemetry ([ae5c3acb](https://github.com/huang-julien/nitro-applicationinsights/commit/ae5c3acb))
+
+### 🏡 Chore
+
+- Update nitro-opentelemetry to 0.5.1 ([ff21c9ee](https://github.com/huang-julien/nitro-applicationinsights/commit/ff21c9ee))
+- Sync nitropack version across workspaces ([b4a274fa](https://github.com/huang-julien/nitro-applicationinsights/commit/b4a274fa))
+- **release:** 1.0.0 ([1045f7e5](https://github.com/huang-julien/nitro-applicationinsights/commit/1045f7e5))
+- Updte nitro-opentelemetry to 0.6.0 ([14af6042](https://github.com/huang-julien/nitro-applicationinsights/commit/14af6042))
+- Remove v0.x type augmentations ([baf7bb22](https://github.com/huang-julien/nitro-applicationinsights/commit/baf7bb22))
+
+### ❤️ Contributors
+
+- Julien Huang ([@huang-julien](http://github.com/huang-julien))
+
 ## v0.15.0
 
 [compare changes](https://github.com/huang-julien/nitro-applicationinsights/compare/v0.14.2...v0.15.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nitro-applicationinsights",
-  "version": "0.15.0",
+  "version": "1.0.0",
   "description": "Application insights plugin for nitro.",
   "repository": "huang-julien/nitro-applicationinsights",
   "license": "MIT",


### PR DESCRIPTION
# V1 release

V1 will include applicationinsights 3 and Opentelemetry integration using [nitro-opentelemetry](https://github.com/huang-julien/nitro-opentelemetry)'s runtime plugin

### Moving to Applicationinsights 3 and Opentelemetry

See [Microsoft applicationinsights documentation](https://learn.microsoft.com/fr-fr/azure/azure-monitor/app/opentelemetry-nodejs-migrate?tabs=upgrade) for changes from applicationinsights 2 to 3.

See [nitro-opentelemetry](https://github.com/huang-julien/nitro-opentelemetry)

- `H3Event.$appInsights` has been removed in favor of Opentelemetry Span.
- `applicationinsights:trackError:before` has been removed.
- `applicationinsights:context:tags` has been removed. You can use `H3Event.context.span.setAttributes()` instead.
- `applicationinsights:trackRequest:before` has been removed. You can use `otel:span:end` nitro-opentelemetry hook instead.
- `applicationinsights:trackError:before` has been removed. You can directly hook into the error hook from nitro instead.
- You need to wrap all your event handlers with `defineTracedEventHandler`. See [event handlers](/event-handlers)