### PR TITLE
feat: setup and ready hooks

### DIFF
--- a/docs/content/2.api/1.hooks.md
+++ b/docs/content/2.api/1.hooks.md
@@ -4,4 +4,7 @@ Available hooks through Nitro
 
 | Hook                                      | Arguments                                                                           | Description                                                           |
 | ----------------------------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `applicationinsights:config`              | config:`TNitroAppInsightsConfig`                                                    | When before starting applicationinsights                              |
+
+| `applicationinsights:setup`              | context: { client: `TelemetryClient`, configuration: `Configuration` }               | Triggered when the applicationinsights client is setup but not initialized                               |
+
+| `applicationinsights:ready`              | context: { client: `TelemetryClient` }                                                    | Triggered when the applicationinsights client is ready and initialized                              |

--- a/playground/plugins/span-processor-example.ts
+++ b/playground/plugins/span-processor-example.ts
@@ -1,0 +1,29 @@
+import { ReadableSpan, Span, SpanProcessor} from "@opentelemetry/sdk-trace-node"
+
+
+ class SpanEnrichingProcessor implements SpanProcessor {
+    forceFlush(): Promise<void> {
+        return Promise.resolve();
+    }
+    onStart(span: Span): void {
+        return;
+    }
+    onEnd(span: ReadableSpan): void {
+        console.log(span)
+    }
+    shutdown(): Promise<void> {
+        return Promise.resolve();
+    }
+}
+
+
+export default defineNitroPlugin((nitro) => {
+    nitro.hooks.hook('applicationinsights:setup', ({ client }) => {
+        client.config.azureMonitorOpenTelemetryOptions = {
+            spanProcessors : [
+                new SpanEnrichingProcessor()
+            ]
+        }
+        
+    })
+})

--- a/src/augment.d.ts
+++ b/src/augment.d.ts
@@ -1,9 +1,21 @@
 import type { TNitroAppInsightsConfig } from './types'
 import { NitroConfig } from 'nitropack';
-
+import type { Configuration, TelemetryClient } from 'applicationinsights';
 declare module 'nitropack' {
   interface NitroRuntimeHooks {
+    /**
+     * @deprecated since 1.1.0 prefer using applicationinsights:setup hook and modify the configuration object
+     */
     'applicationinsights:config': (config: TNitroAppInsightsConfig) => void
+    /**
+     * Run when the applicationinsights client is setup but not started
+     * If you want to modify azure monitors options you can do it here
+     */
+    'applicationinsights:setup': (context: { client: TelemetryClient, configuration: Configuration }) => void
+    /**
+     * Run when the applicationinsights client is ready and initialized
+     */
+    'applicationinsights:ready': (context: { client: TelemetryClient }) => void
   }
 
   interface NitroRuntimeConfig {

--- a/src/augment.d.ts
+++ b/src/augment.d.ts
@@ -8,12 +8,12 @@ declare module 'nitropack' {
      */
     'applicationinsights:config': (config: TNitroAppInsightsConfig) => void
     /**
-     * Run when the applicationinsights client is setup but not started
+     * Triggered when the applicationinsights client is setup but not started
      * If you want to modify azure monitors options you can do it here
      */
     'applicationinsights:setup': (context: { client: TelemetryClient, configuration: Configuration }) => void
     /**
-     * Run when the applicationinsights client is ready and initialized
+     * Triggered when the applicationinsights client is ready and initialized
      */
     'applicationinsights:ready': (context: { client: TelemetryClient }) => void
   }

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,5 +1,4 @@
 import type { NitroAppPlugin } from 'nitropack'
-import defu from 'defu'
 import type { TNitroAppInsightsConfig } from '../types'
 import { useRuntimeConfig } from '#imports'
 import _Applicationinsights from 'applicationinsights'
@@ -25,30 +24,7 @@ loadInstrumentations()
 const Applicationinsights = _Applicationinsights as typeof import('applicationinsights')
 
 export default <NitroAppPlugin>(async (nitro) => {
-  const { applicationinsights } = useRuntimeConfig()
-
-  const config: TNitroAppInsightsConfig = defu(applicationinsights, {
-    connectionString: undefined,
-    autoCollectRequests: false,
-    autoCollectConsole: false,
-    autoCollectDependencies: false,
-    autoCollectExceptions: false,
-    autoCollectPerformance: {
-      value: false,
-    },
-    autoCollectHeartbeat: false,
-    autoCollectIncomingRequestAzureFunctions: false,
-    autoCollectPreAggregatedMetrics: false,
-    autoDependencyCorrelation: false,
-    enableWebInstrumentation: false,
-    distributedTracingMode: Applicationinsights.DistributedTracingModes.AI_AND_W3C,
-    sendLiveMetrics: false,
-    internalLogging: {
-      enableDebugLogging: false,
-      enableWarningLogging: false
-    },
-    useDiskRetryCaching: false
-  })
+  const { applicationinsights: config } = useRuntimeConfig()
 
   await nitro.hooks.callHook('applicationinsights:config', config)
 
@@ -84,19 +60,43 @@ export default <NitroAppPlugin>(async (nitro) => {
 
 export function setup(config: TNitroAppInsightsConfig) {
   // Setup Application Insights using the instrumentation key from the environment variables
-  const configuration = Applicationinsights
-    .setup(config.connectionString)
-    .setAutoCollectRequests(config.autoCollectRequests)
-    .setAutoCollectDependencies(config.autoCollectDependencies)
-    .setAutoCollectExceptions(config.autoCollectExceptions)
-    .setAutoCollectHeartbeat(config.autoCollectHeartbeat)
-    .setAutoCollectIncomingRequestAzureFunctions(config.autoCollectIncomingRequestAzureFunctions)
-    .setAutoCollectPreAggregatedMetrics(config.autoCollectPreAggregatedMetrics)
-    .setDistributedTracingMode(config.distributedTracingMode)
-    .setSendLiveMetrics(config.sendLiveMetrics).setInternalLogging(true, true) // Enable both debug and warning logging
-    .setAutoCollectConsole(true, true) // Generate Trace telemetry for winston/bunyan and console logs
+  const configuration = Applicationinsights.setup(config.connectionString)
 
-    .setUseDiskRetryCaching(config.useDiskRetryCaching)
+  if (config.autoCollectRequests !== undefined) {
+    configuration.setAutoCollectRequests(config.autoCollectRequests)
+  }
+
+  if (config.autoCollectDependencies !== undefined) {
+    configuration.setAutoCollectDependencies(config.autoCollectDependencies)
+  }
+
+  if (config.autoCollectExceptions !== undefined) {
+    configuration.setAutoCollectExceptions(config.autoCollectExceptions)
+  }
+
+  if (config.autoCollectHeartbeat !== undefined) {
+    configuration.setAutoCollectHeartbeat(config.autoCollectHeartbeat)
+  }
+
+  if (config.autoCollectIncomingRequestAzureFunctions !== undefined) {
+    configuration.setAutoCollectIncomingRequestAzureFunctions(config.autoCollectIncomingRequestAzureFunctions)
+  }
+
+  if (config.autoCollectPreAggregatedMetrics !== undefined) {
+    configuration.setAutoCollectPreAggregatedMetrics(config.autoCollectPreAggregatedMetrics)
+  }
+
+  if (config.distributedTracingMode !== undefined) {
+    configuration.setDistributedTracingMode(config.distributedTracingMode)
+  }
+
+  if (config.sendLiveMetrics !== undefined) {
+    configuration.setSendLiveMetrics(config.sendLiveMetrics)
+  }
+
+  if (config.useDiskRetryCaching !== undefined) {
+    configuration.setUseDiskRetryCaching(config.useDiskRetryCaching)
+  }
 
   if (typeof config.autoCollectPerformance === 'object') {
     configuration.setAutoCollectPerformance(config.autoCollectPerformance.value, config.autoCollectPerformance.collectExtendedMetrics)

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -52,7 +52,9 @@ export default <NitroAppPlugin>(async (nitro) => {
 
   await nitro.hooks.callHook('applicationinsights:config', config)
 
-  setup(config)
+  const configuration = setup(config)
+  await nitro.hooks.callHook('applicationinsights:setup', { client: Applicationinsights.defaultClient, configuration })
+  configuration.start()
 
   registerInstrumentations({
     tracerProvider: trace.getTracerProvider(),
@@ -123,5 +125,5 @@ export function setup(config: TNitroAppInsightsConfig) {
     configuration.setInternalLogging(config.internalLogging)
   }
 
-  return configuration.start()
+  return configuration
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,18 +4,60 @@ import type { DistributedTracingModes } from 'applicationinsights'
 
 export type TNitroAppInsightsConfig = {
   connectionString?: string
+  /**
+   * @deprecated since 1.1.0 prefer using applicationinsights:setup hook and modify the configuration object
+   */
   autoCollectRequests: boolean
+  /**
+   * @deprecated since 1.1.0 prefer using applicationinsights:setup hook and modify the configuration object
+   */
   autoCollectConsole: boolean | {value: boolean, collectConsoleLogs: boolean}
+  /**
+   * @deprecated since 1.1.0 prefer using applicationinsights:setup hook and modify the configuration object
+   */
   autoCollectDependencies: boolean
+  /**
+   * @deprecated since 1.1.0 prefer using applicationinsights:setup hook and modify the configuration object
+   */
   autoCollectExceptions: boolean
+  /**
+   * @deprecated since 1.1.0 prefer using applicationinsights:setup hook and modify the configuration object
+   */
   autoCollectPerformance: {value :boolean, collectExtendedMetrics: boolean}
+  /**
+   * @deprecated since 1.1.0 prefer using applicationinsights:setup hook and modify the configuration object
+   */
   autoCollectHeartbeat: boolean
+  /**
+   * @deprecated since 1.1.0 prefer using applicationinsights:setup hook and modify the configuration object
+   */
   autoCollectIncomingRequestAzureFunctions: boolean
+  /**
+   * @deprecated since 1.1.0 prefer using applicationinsights:setup hook and modify the configuration object
+   */
   autoCollectPreAggregatedMetrics: boolean
+  /**
+   * @deprecated since 1.1.0 prefer using applicationinsights:setup hook and modify the configuration object
+   */
   autoDependencyCorrelation: boolean | {value :boolean, useAsyncHooks :boolean}
+  /**
+   * @deprecated since 1.1.0 prefer using applicationinsights:setup hook and modify the configuration object
+   */
   enableWebInstrumentation: boolean | {value: boolean, WebSnippetConnectionString?: string}
+  /**
+   * @deprecated since 1.1.0 prefer using applicationinsights:setup hook and modify the configuration object
+   */
   distributedTracingMode: DistributedTracingModes
+  /**
+   * @deprecated since 1.1.0 prefer using applicationinsights:setup hook and modify the configuration object
+   */
   sendLiveMetrics:boolean
+  /**
+   * @deprecated since 1.1.0 prefer using applicationinsights:setup hook and modify the configuration object
+   */
   internalLogging: {enableDebugLogging?: boolean, enableWarningLogging?: boolean}
+  /**
+   * @deprecated since 1.1.0 prefer using applicationinsights:setup hook and modify the configuration object
+   */
   useDiskRetryCaching: boolean
 }


### PR DESCRIPTION
this PR deprecates the old `applicationinsights:config` hook in order to be more reliable in case of future applicationinsights api changes.

it also introduces new hooks so users can modify and configure applicationinsights + azure monitor before starting it