### PR TITLE
fix: bind instrumentations to the tracer provider after setup

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -35,6 +35,7 @@ export default <NitroAppPlugin>(async (nitro) => {
   await nitro.hooks.callHook('applicationinsights:ready', { client: Applicationinsights.defaultClient })
 
   registerInstrumentations({
+    instrumentations,
     tracerProvider: trace.getTracerProvider(),
     meterProvider: metrics.getMeterProvider(),
   });


### PR DESCRIPTION
Fixes #289.

`UndiciInstrumentation` and `HttpInstrumentation` are constructed at module load, before `applicationinsights` installs a tracer provider. The second `registerInstrumentations()` call is meant to re-bind them once the provider exists, but it omits the `instrumentations` key  and `registerInstrumentations` iterates `options.instrumentations ?? []`, so it re-binds nothing.

The instrumentations therefore keep the unresolved `ProxyTracer` they captured at construction, and every outbound span is created non-recording and silently dropped, so no `fetch`/undici dependencies reach App Insights at all.

Passing `instrumentations` makes `InstrumentationBase.setTracerProvider()` run, which replaces `_tracer` with a tracer from the live provider.

Verified with the standalone repro in #289: 0 dependency spans recorded before, 4 after, with no other change.

Two notes on scope:

- The `loadInstrumentations()` call at module load is left alone. It still needs to run early so the diagnostics-channel subscriptions are in place before the first request; this only adds the missing re-bind afterwards.
- No test included. Exercising this needs a live `applicationinsights` setup plus reaching into the provider's active span processor, which seemed heavier than the fix warrants, happy to add one if you'd like it.