### PR TITLE
perf: prevent application insights import if disabled

### DIFF
--- a/docs/content/1.guide/3.runtime-configuration.md
+++ b/docs/content/1.guide/3.runtime-configuration.md
@@ -27,3 +27,12 @@ type TNitroAppInsightsConfig = {
 ::alert
 See more at the [hook documentation](/api/hooks)
 ::
+
+## Disabling telemetry at runtime
+
+The `applicationinsights` SDK is only loaded when a connection string is available. The plugin resolves it in this order:
+
+1. `runtimeConfig.applicationinsights.connectionString` (possibly modified through the `applicationinsights:config` hook)
+2. the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable
+3. the `APPINSIGHTS_INSTRUMENTATIONKEY` environment variable
+

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,66 +1,77 @@
-import type { NitroAppPlugin } from 'nitropack'
+import type { NitroApp, NitroAppPlugin } from 'nitropack'
 import type { TNitroAppInsightsConfig } from '../types'
 import { useRuntimeConfig } from '#imports'
-import _Applicationinsights from 'applicationinsights'
 import { metrics, trace, } from "@opentelemetry/api";
-import { registerInstrumentations } from "@opentelemetry/instrumentation";
-import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici"
-import { HttpInstrumentation } from "@opentelemetry/instrumentation-http"
-import { SEMATTRS_HTTP_URL, SEMATTRS_HTTP_HOST, SEMATTRS_HTTP_METHOD, SEMATTRS_HTTP_ROUTE, SEMATTRS_HTTP_SCHEME, SEMATTRS_HTTP_STATUS_CODE, OTEL_STATUS_CODE_VALUE_OK, OTEL_STATUS_CODE_VALUE_ERROR } from "@opentelemetry/semantic-conventions"
+import { SEMATTRS_HTTP_URL, SEMATTRS_HTTP_HOST, SEMATTRS_HTTP_METHOD, SEMATTRS_HTTP_ROUTE, SEMATTRS_HTTP_SCHEME, SEMATTRS_HTTP_STATUS_CODE } from "@opentelemetry/semantic-conventions"
 import { getResponseStatus, getRequestURL, getRequestProtocol } from 'h3'
 import { defu } from 'defu';
 
-const instrumentations = [
-  new UndiciInstrumentation(),
-  new HttpInstrumentation()
-];
-const loadInstrumentations = () => {
-  registerInstrumentations({
-    instrumentations,
-  });
-}
-loadInstrumentations()
-
-
-const Applicationinsights = _Applicationinsights as typeof import('applicationinsights')
-
-export default <NitroAppPlugin>(async (nitro) => {
-  const { applicationinsights: config } = useRuntimeConfig()
-
-  await nitro.hooks.callHook('applicationinsights:config', defu(config, {}))
-
-  const configuration = setup(config)
-  await nitro.hooks.callHook('applicationinsights:setup', { client: Applicationinsights.defaultClient, configuration })
-  configuration.start()
-  await nitro.hooks.callHook('applicationinsights:ready', { client: Applicationinsights.defaultClient })
-
-  registerInstrumentations({
-    instrumentations,
-    tracerProvider: trace.getTracerProvider(),
-    meterProvider: metrics.getMeterProvider(),
-  });
-  
-  nitro.hooks.hook('otel:span:end', ({event}) => {
-    event.otel.span.setAttributes({
-      [SEMATTRS_HTTP_STATUS_CODE]: getResponseStatus(event),
+export default <NitroAppPlugin>((nitro) => {
+  let enabled = false
+  const ready = initialize(nitro)
+    .then((started) => { enabled = started === true })
+    .catch((error) => {
+      nitro.captureError(error, { tags: ['applicationinsights'] })
     })
-  })
 
-  // azure app insights seems to be relying on the deprecated attributes
-  nitro.hooks.hook('request', async (event) => {
+  // block requests until the SDK is initialized
+  const unhook = nitro.hooks.hook('request', () => ready)
+  ready.finally(unhook)
+ 
+  nitro.hooks.hook('otel:span:end', async ({ event }) => {
+    if (!enabled) { return }
+
     const requestURL = getRequestURL(event)
     event.otel.span.setAttributes({
       [SEMATTRS_HTTP_ROUTE]: (await nitro.h3App.resolve(event.path))?.route || event.path,
       [SEMATTRS_HTTP_URL]: event.path,
       [SEMATTRS_HTTP_METHOD]: event.method,
       [SEMATTRS_HTTP_SCHEME]: getRequestProtocol(event),
-      [SEMATTRS_HTTP_HOST]: requestURL.host, 
+      [SEMATTRS_HTTP_HOST]: requestURL.host,
+      [SEMATTRS_HTTP_STATUS_CODE]: getResponseStatus(event),
     })
   })
 })
 
+async function initialize(nitro: NitroApp): Promise<boolean> {
+  const config = defu(useRuntimeConfig().applicationinsights, {}) as TNitroAppInsightsConfig
 
-export function setup(config: TNitroAppInsightsConfig) {
+  await nitro.hooks.callHook('applicationinsights:config', config)
+
+  // applicationinsights use the connection string from the config or from the environment variables
+  const connectionString = config.connectionString
+    || process.env.APPLICATIONINSIGHTS_CONNECTION_STRING
+    || process.env.APPINSIGHTS_INSTRUMENTATIONKEY
+
+  // skip loading the whole applicationinsights graph when telemetry cannot be sent anywhere
+  if (!connectionString) { return false }
+
+  const [appInsightsModule, { registerInstrumentations }, { UndiciInstrumentation }, { HttpInstrumentation }] = await Promise.all([
+    import('applicationinsights'),
+    import('@opentelemetry/instrumentation'),
+    import('@opentelemetry/instrumentation-undici'),
+    import('@opentelemetry/instrumentation-http'),
+  ])
+  const Applicationinsights = (appInsightsModule.default ?? appInsightsModule) as typeof import('applicationinsights')
+
+  const configuration = setup(Applicationinsights, config)
+  await nitro.hooks.callHook('applicationinsights:setup', { client: Applicationinsights.defaultClient, configuration })
+  configuration.start()
+  await nitro.hooks.callHook('applicationinsights:ready', { client: Applicationinsights.defaultClient })
+
+  registerInstrumentations({
+    instrumentations: [
+      new UndiciInstrumentation(),
+      new HttpInstrumentation(),
+    ],
+    tracerProvider: trace.getTracerProvider(),
+    meterProvider: metrics.getMeterProvider(),
+  });
+  return true
+}
+
+
+function setup(Applicationinsights: typeof import('applicationinsights'), config: TNitroAppInsightsConfig) {
   // Setup Application Insights using the instrumentation key from the environment variables
   const configuration = Applicationinsights.setup(config.connectionString)
 

--- a/test/fixtures/basic/plugins/applicationinsights-hooks.ts
+++ b/test/fixtures/basic/plugins/applicationinsights-hooks.ts
@@ -1,0 +1,25 @@
+declare module 'h3' {
+  interface H3EventContext {
+    applicationinsightsHooks?: string[]
+  }
+}
+
+export default defineNitroPlugin((nitro) => {
+  const hooks: string[] = []
+
+  nitro.hooks.hook('applicationinsights:config', (config) => {
+    hooks.push(`config:${typeof config.connectionString === 'string'}`)
+  })
+
+  nitro.hooks.hook('applicationinsights:setup', ({ client, configuration }) => {
+    hooks.push(`setup:${Boolean(client && configuration)}`)
+  })
+
+  nitro.hooks.hook('applicationinsights:ready', ({ client }) => {
+    hooks.push(`ready:${Boolean(client)}`)
+  })
+
+  nitro.hooks.hook('request', (event) => {
+    event.context.applicationinsightsHooks = hooks
+  })
+})

--- a/test/fixtures/basic/routes/hooks.ts
+++ b/test/fixtures/basic/routes/hooks.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler((event) => {
+  return { hooks: event.context.applicationinsightsHooks ?? [] }
+})

--- a/test/fixtures/hook-connection-string/nitro.config.ts
+++ b/test/fixtures/hook-connection-string/nitro.config.ts
@@ -1,0 +1,5 @@
+import { defineNitroConfig } from 'nitropack/config'
+
+export default defineNitroConfig({
+  modules: ['../../../src/index.ts']
+})

--- a/test/fixtures/hook-connection-string/package.json
+++ b/test/fixtures/hook-connection-string/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "scripts": {
+    "prepare": "nitropack prepare",
+    "dev": "nitropack dev",
+    "build": "nitropack build",
+    "preview": "node .output/server/index.mjs"
+  },
+  "dependencies": {
+    "nitro-applicationinsights": "workspace:*",
+    "nitropack": "2.10.4"
+  }
+}

--- a/test/fixtures/hook-connection-string/plugins/applicationinsights-hooks.ts
+++ b/test/fixtures/hook-connection-string/plugins/applicationinsights-hooks.ts
@@ -1,0 +1,27 @@
+declare module 'h3' {
+  interface H3EventContext {
+    applicationinsightsHooks?: string[]
+  }
+}
+
+export default defineNitroPlugin((nitro) => {
+  const hooks: string[] = []
+
+  // no connection string in the runtime config: inject it through the hook instead
+  nitro.hooks.hook('applicationinsights:config', (config) => {
+    config.connectionString = 'InstrumentationKey=00000000-0000-0000-0000-000000000000;'
+    hooks.push('config')
+  })
+
+  nitro.hooks.hook('applicationinsights:setup', () => {
+    hooks.push('setup')
+  })
+
+  nitro.hooks.hook('applicationinsights:ready', () => {
+    hooks.push('ready')
+  })
+
+  nitro.hooks.hook('request', (event) => {
+    event.context.applicationinsightsHooks = hooks
+  })
+})

--- a/test/fixtures/hook-connection-string/routes/hooks.ts
+++ b/test/fixtures/hook-connection-string/routes/hooks.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler((event) => {
+  return { hooks: event.context.applicationinsightsHooks ?? [] }
+})

--- a/test/fixtures/no-connection-string/nitro.config.ts
+++ b/test/fixtures/no-connection-string/nitro.config.ts
@@ -1,0 +1,5 @@
+import { defineNitroConfig } from 'nitropack/config'
+
+export default defineNitroConfig({
+  modules: ['../../../src/index.ts']
+})

--- a/test/fixtures/no-connection-string/package.json
+++ b/test/fixtures/no-connection-string/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "scripts": {
+    "prepare": "nitropack prepare",
+    "dev": "nitropack dev",
+    "build": "nitropack build",
+    "preview": "node .output/server/index.mjs"
+  },
+  "dependencies": {
+    "nitro-applicationinsights": "workspace:*",
+    "nitropack": "2.10.4"
+  }
+}

--- a/test/fixtures/no-connection-string/plugins/applicationinsights-hooks.ts
+++ b/test/fixtures/no-connection-string/plugins/applicationinsights-hooks.ts
@@ -1,0 +1,25 @@
+declare module 'h3' {
+  interface H3EventContext {
+    applicationinsightsHooks?: string[]
+  }
+}
+
+export default defineNitroPlugin((nitro) => {
+  const hooks: string[] = []
+
+  nitro.hooks.hook('applicationinsights:config', () => {
+    hooks.push('config')
+  })
+
+  nitro.hooks.hook('applicationinsights:setup', () => {
+    hooks.push('setup')
+  })
+
+  nitro.hooks.hook('applicationinsights:ready', () => {
+    hooks.push('ready')
+  })
+
+  nitro.hooks.hook('request', (event) => {
+    event.context.applicationinsightsHooks = hooks
+  })
+})

--- a/test/fixtures/no-connection-string/routes/hooks.ts
+++ b/test/fixtures/no-connection-string/routes/hooks.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler((event) => {
+  return { hooks: event.context.applicationinsightsHooks ?? [] }
+})

--- a/test/fixtures/no-connection-string/routes/index.ts
+++ b/test/fixtures/no-connection-string/routes/index.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(() => {
+  return { ok: true }
+})

--- a/test/hook-connection-string.test.ts
+++ b/test/hook-connection-string.test.ts
@@ -1,0 +1,18 @@
+import { expect, it, describe } from 'vitest'
+import { $fetchRaw as $fetch, setup } from 'nitro-test-utils/e2e'
+import { dirname } from 'pathe'
+import { resolvePathSync } from 'mlly'
+
+await setup({
+  rootDir: dirname(resolvePathSync('./fixtures/hook-connection-string/nitro.config.ts', {
+    url: import.meta.url
+  }))
+})
+
+describe('connection string provided through the applicationinsights:config hook', () => {
+  it('expect the SDK to be set up with the injected connection string', async () => {
+    const { data } = await $fetch<{ hooks: string[] }>('/hooks')
+
+    expect(data!.hooks).toEqual(['config', 'setup', 'ready'])
+  })
+})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -50,3 +50,11 @@ describe('trace', () => {
     expect(data!.dependencyTrace.split('-')[1]).toBe(data!.trace.split('-')[1])
   })
 })
+
+describe('hooks', () => {
+  it('expect config, setup and ready hooks to be called in order with their payloads', async () => {
+    const { data } = await $fetch<{ hooks: string[] }>('/hooks')
+
+    expect(data!.hooks).toEqual(['config:true', 'setup:true', 'ready:true'])
+  })
+})

--- a/test/no-connection-string.test.ts
+++ b/test/no-connection-string.test.ts
@@ -1,0 +1,25 @@
+import { expect, it, describe } from 'vitest'
+import { $fetchRaw as $fetch, setup } from 'nitro-test-utils/e2e'
+import { dirname } from 'pathe'
+import { resolvePathSync } from 'mlly'
+
+await setup({
+  rootDir: dirname(resolvePathSync('./fixtures/no-connection-string/nitro.config.ts', {
+    url: import.meta.url
+  }))
+})
+
+describe('without a connection string', () => {
+  it('expect the server to boot and respond without loading the SDK', async () => {
+    const { data, status } = await $fetch<{ ok: boolean }>('/')
+
+    expect(status).toBe(200)
+    expect(data).toEqual({ ok: true })
+  })
+
+  it('expect only the config hook to be called', async () => {
+    const { data } = await $fetch<{ hooks: string[] }>('/hooks')
+
+    expect(data!.hooks).toEqual(['config'])
+  })
+})


### PR DESCRIPTION
fix https://github.com/huang-julien/nitro-applicationinsights/issues/291

This pR make anything from applicaitoninsights and OTEL lazy imported and trigger setup + import only if connectionString is provided, whether through:
- env var
- config
- hook


It also removes the early instrumentation registration which shouldn't impact `$fetch` or native fetch.
